### PR TITLE
#292: only import ns which has pvcs

### DIFF
--- a/pkg/operation/velero_operation.go
+++ b/pkg/operation/velero_operation.go
@@ -172,6 +172,12 @@ func (o *Operation) EnsureVeleroRestore(backupName, namespace, dataImport, rateL
 		excludedResources = append(excludedResources, "persistentvolumeclaims")
 		excludedResources = append(excludedResources, "persistentvolumes")
 	}
+
+	var includedNamespaces []string
+	for key := range nsMapping {
+		includedNamespaces = append(includedNamespaces, key)
+	}
+
 	var annotations map[string]string
 	if len(rateLimit) > 0 {
 		annotations = make(map[string]string)
@@ -184,10 +190,11 @@ func (o *Operation) EnsureVeleroRestore(backupName, namespace, dataImport, rateL
 			Annotations: annotations,
 		},
 		Spec: velero.RestoreSpec{
-			BackupName:        backupName,
-			RestorePVs:        &(config.True),
-			ExcludedResources: excludedResources,
-			NamespaceMapping:  nsMapping,
+			BackupName:         backupName,
+			RestorePVs:         &(config.True),
+			ExcludedResources:  excludedResources,
+			NamespaceMapping:   nsMapping,
+			IncludedNamespaces: includedNamespaces,
 		},
 	}
 	err := o.client.Create(context.TODO(), restore)


### PR DESCRIPTION
UT result;

backup wordpress and okd namespace, okd doesnt have pvcs.  includedNamespaces in velero restore only contain dm-wordpress-bqdv6

  k -n qiming-backend get restores vi-di-data-only-restore-2g5cg -o yaml
apiVersion: velero.io/v1
kind: Restore
metadata:
  creationTimestamp: "2022-03-16T06:57:07Z"
  generation: 4
  name: vi-di-data-only-restore-2g5cg
  namespace: qiming-backend
  resourceVersion: "6829207"
  uid: 3a4697a5-9db7-40c4-9dbd-ee73733e67ee
spec:
  backupName: ve-wordpress-dm-5vqbj-bqdv6
  excludedResources:
  - nodes
  - events
  - events.events.k8s.io
  - backups.velero.io
  - restores.velero.io
  - resticrepositories.velero.io
  hooks: {}
  **includedNamespaces:**
  **- dm-wordpress-bqdv6
  namespaceMapping:
    dm-wordpress-bqdv6: wordpress**
  restorePVs: true
status:
  completionTimestamp: "2022-03-16T06:57:19Z"
  phase: Completed
  progress:
    itemsRestored: 10
    totalItems: 10
  startTimestamp: "2022-03-16T06:57:07Z"
heping@Hepings-MacBook-Pro jibu % k get ns
NAME               STATUS   AGE
calico-system      Active   14d
default            Active   14d
kube-node-lease    Active   14d
kube-public        Active   14d
kube-system        Active   14d
okd                Active   65s
qiming-backend     Active   2d19h
qiming-migration   Active   16m
rook-ceph          Active   14d
tigera-operator    Active   14d
wordpress          Active   2m51s